### PR TITLE
Avoid need for diff image writing

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,18 +27,18 @@ function pixelmatch(img1, img2, output, width, height, options) {
                 if (!options.includeAA && (antialiased(img1, x, y, width, height, img2) ||
                                    antialiased(img2, x, y, width, height, img1))) {
                     // one of the pixels is anti-aliasing; draw as yellow and do not count as difference
-                    drawPixel(output, pos, 255, 255, 0);
+                    if (output) drawPixel(output, pos, 255, 255, 0);
 
                 } else {
                     // found substantial difference not caused by anti-aliasing; draw it as red
-                    drawPixel(output, pos, 255, 0, 0);
+                    if (output) drawPixel(output, pos, 255, 0, 0);
                     diff++;
                 }
 
             } else {
                 // pixels are similar; draw background as grayscale image blended with white
                 var val = 255 - 0.1 * (255 - grayPixel(img1, pos)) * img1[pos + 3] / 255;
-                drawPixel(output, pos, val, val, val);
+                if (output) drawPixel(output, pos, val, val, val);
             }
         }
     }

--- a/test/test.js
+++ b/test/test.js
@@ -26,8 +26,14 @@ function diffTest(imgPath1, imgPath2, diffPath, threshold, includeAA, expectedMi
                         includeAA: includeAA
                     });
 
+                    var mismatch2 = match(img1.data, img2.data, null, diff.width, diff.height, {
+                        threshold: threshold,
+                        includeAA: includeAA
+                    });
+
                     t.same(diff.data, expectedDiff.data, 'diff image');
                     t.same(mismatch, expectedMismatch, 'number of mismatched pixels');
+                    t.same(mismatch, mismatch2, 'number of mismatched pixels');
 
                     t.end();
                 });


### PR DESCRIPTION
When running `pixelmatch` on lots of images when only the mismatch # is needed, it can save time to avoid needing to allocate the `diff` image.

I'm not sure if this is the cleanest approach, but wanted to put this forward to get the idea started.

/cc @lbud 