### PR TITLE
Update PNG library

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ pixelmatch image1.png image2.png output.png 0.1
 
 ```js
 var fs = require('fs'),
-    PNG = require('pngjs2').PNG,
+    PNG = require('pngjs').PNG,
     pixelmatch = require('pixelmatch');
 
 var img1 = fs.createReadStream('img1.png').pipe(new PNG()).on('parsed', doneReading),

--- a/bin/pixelmatch
+++ b/bin/pixelmatch
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 'use strict';
 
-var PNG = require('pngjs2').PNG,
+var PNG = require('pngjs').PNG,
     fs = require('fs'),
     match = require('../.');
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "pixelmatch": "bin/pixelmatch"
   },
   "dependencies": {
-    "pngjs2": "^2.0.0"
+    "pngjs": "^2.1.0"
   },
   "devDependencies": {
     "eslint": "^1.6.0",

--- a/test/test.js
+++ b/test/test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var PNG = require('pngjs2').PNG,
+var PNG = require('pngjs').PNG,
     fs = require('fs'),
     test = require('tap').test,
     path = require('path'),


### PR DESCRIPTION
The `pngjs2` project has been merged (back?) into `pngjs`. Consequently, `pngjs2` is now deprecated and `pngjs` is the latest version. Confused? I was too.

Consequently, PixelMatch is currently giving the following warning when being installed:

```
npm WARN deprecated pngjs2@2.0.0: pngjs2 has now taken over the original pngjs package on npm. Please change to use pngjs dependency, version 2+.
```

This pull request will update to the latest library and cure this warning. No API changes are needed on your part.

And thanks for the very hot library, which I have included here: https://github.com/oliver-moran/jimp