### PR TITLE
Bug fix for different results when switching entries

### DIFF
--- a/bin/pixelmatch
+++ b/bin/pixelmatch
@@ -18,10 +18,10 @@ var img2 = fs.createReadStream(process.argv[3]).pipe(new PNG()).on('parsed', don
 function doneReading() {
     if (!img1.data || !img2.data) return;
 
-    var diff = new PNG({width: this.width, height: this.height});
+    var diff = new PNG({width: img1.width, height: img1.height});
 
     console.time('match');
-    var diffs = match(img1.data, this.data, diff.data, this.width, this.height, {
+    var diffs = match(img1.data, img2.data, diff.data, diff.width, diff.height, {
         threshold: threshold,
         includeAA: includeAA
     });


### PR DESCRIPTION
See https://github.com/mapbox/pixelmatch/issues/10
Furthermore this bug fix adds more consistency between the CLI and the
tests by correcting the order of the params passed to the match function