### PR TITLE
Put pngjs to dev dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,12 +6,10 @@
   "bin": {
     "pixelmatch": "bin/pixelmatch"
   },
-  "dependencies": {
-    "pngjs": "^3.3.2"
-  },
   "devDependencies": {
     "eslint": "^4.18.1",
     "eslint-config-mourner": "^2.0.3",
+    "pngjs": "^3.3.2",
     "tap": "^11.1.1"
   },
   "scripts": {


### PR DESCRIPTION
`pngjs` is not being used from main entry, so installation can be eased.