### PR TITLE
Horizontal shift threshold

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,10 @@
 module.exports = pixelmatch;
 
 const defaultOptions = {
-    threshold: 0.1,         // matching threshold (0 to 1); smaller is more sensitive
-    horizontalShiftPixels: 3, // Check matches within X many pixels of current pixel
-    includeAA: false,       // whether to skip anti-aliasing detection
+    threshold: 0.5,         // matching threshold (0 to 1); smaller is more sensitive
+    horizontalShiftPixels: 5, // Check matches within X many pixels of current pixel
+    verticalShiftPixels: 1, // Check matches within Y many pixels of current pixel
+    includeAA: true,       // whether to skip anti-aliasing detection
     alpha: 0.1,             // opacity of original image in diff output
     aaColor: [255, 255, 0], // color of anti-aliased pixels in diff output
     diffColor: [255, 0, 0], // color of different pixels in diff output
@@ -57,23 +58,22 @@ function pixelmatch(img1, img2, output, width, height, options) {
             let minAbsDelta = 9999;
             let minOtherDelta = 9999;
             for(let hShift = -1*options.horizontalShiftPixels; hShift <= options.horizontalShiftPixels; ++hShift){
-                if(x+hShift < 0 || x+hShift > width){
-                    //Ignore shifts of pixels outside the image
-                    continue;
-                }
-                const currDelta = Math.abs(colorDelta(img1, img2, pos, pos+hShift*4))
-                if(currDelta < minAbsDelta){
-                    minAbsDelta = currDelta
-                }
-                const otherDelta = Math.abs(colorDelta(img1, img2, pos+hShift*4, pos))
-                if(otherDelta < minOtherDelta){
-                    minOtherDelta = otherDelta
+                for(let vShift = -1*options.verticalShiftPixels; vShift <= options.verticalShiftPixels; ++vShift){
+                    if(x+hShift < 0 || x+hShift > width || y+vShift < 0 || y+vShift > height){
+                        //Ignore shifts of pixels outside the image
+                        continue;
+                    }
+                    const currDelta = Math.abs(colorDelta(img1, img2, pos, pos+((width*vShift)+hShift)*4))
+                    if(currDelta < minAbsDelta){
+                        minAbsDelta = currDelta
+                    }
+                    const otherDelta = Math.abs(colorDelta(img1, img2, pos+((width*vShift)+hShift)*4, pos))
+                    if(otherDelta < minOtherDelta){
+                        minOtherDelta = otherDelta
+                    }
                 }
             }
             const delta = Math.max(minAbsDelta, minOtherDelta)
-            // if(delta > 0){
-            //     console.log(`${x} x ${y} MINdelta = ${delta}`)
-            // }
 
             // the color difference is above the threshold
             if (Math.abs(delta) > maxDelta) {

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ module.exports = pixelmatch;
 
 const defaultOptions = {
     threshold: 0.5,         // matching threshold (0 to 1); smaller is more sensitive
-    horizontalShiftPixels: 5, // Check matches within X many pixels of current pixel
-    verticalShiftPixels: 1, // Check matches within Y many pixels of current pixel
+    horizontalShiftPixels: 10, // Check matches within X many pixels of current pixel
+    verticalShiftPixels: 5, // Check matches within Y many pixels of current pixel
     includeAA: true,       // whether to skip anti-aliasing detection
     alpha: 0.1,             // opacity of original image in diff output
     aaColor: [255, 255, 0], // color of anti-aliased pixels in diff output
@@ -54,26 +54,32 @@ function pixelmatch(img1, img2, output, width, height, options) {
             const pos = (y * width + x) * 4;
 
             // squared YUV distance between colors at this pixel position, negative if the img2 pixel is darker
-            // const delta = colorDelta(img1, img2, pos, pos);
-            let minAbsDelta = 9999;
-            let minOtherDelta = 9999;
-            for(let hShift = -1*options.horizontalShiftPixels; hShift <= options.horizontalShiftPixels; ++hShift){
-                for(let vShift = -1*options.verticalShiftPixels; vShift <= options.verticalShiftPixels; ++vShift){
-                    if(x+hShift < 0 || x+hShift > width || y+vShift < 0 || y+vShift > height){
-                        //Ignore shifts of pixels outside the image
-                        continue;
-                    }
-                    const currDelta = Math.abs(colorDelta(img1, img2, pos, pos+((width*vShift)+hShift)*4))
-                    if(currDelta < minAbsDelta){
-                        minAbsDelta = currDelta
-                    }
-                    const otherDelta = Math.abs(colorDelta(img1, img2, pos+((width*vShift)+hShift)*4, pos))
-                    if(otherDelta < minOtherDelta){
-                        minOtherDelta = otherDelta
+            let delta = colorDelta(img1, img2, pos, pos);
+            if((delta > maxDelta || delta < -1*maxDelta) && (options.horizontalShiftPixels > 0 || options.verticalShiftPixels > 0)){
+                let minAbsDelta = 9999;
+                let minOtherDelta = 9999;
+                for(let hShift = -1*options.horizontalShiftPixels; hShift <= options.horizontalShiftPixels; ++hShift){
+                    for(let vShift = -1*options.verticalShiftPixels; vShift <= options.verticalShiftPixels; ++vShift){
+                        if(x+hShift < 0 || x+hShift > width || y+vShift < 0 || y+vShift > height){
+                            //Ignore shifts of pixels outside the image
+                            continue;
+                        }
+                        const currDelta = colorDelta(img1, img2, pos, pos+((width*vShift)+hShift)*4)
+                        if(Math.abs(currDelta) < Math.abs(minAbsDelta)){
+                            minAbsDelta = currDelta
+                        }
+                        const otherDelta = colorDelta(img1, img2, pos+((width*vShift)+hShift)*4, pos)
+                        if(Math.abs(otherDelta) < Math.abs(minOtherDelta)){
+                            minOtherDelta = otherDelta
+                        }
                     }
                 }
+                if(Math.abs(minAbsDelta) > Math.abs(minOtherDelta)){
+                    delta = minAbsDelta
+                } else {
+                    delta = minOtherDelta
+                }
             }
-            const delta = Math.max(minAbsDelta, minOtherDelta)
 
             // the color difference is above the threshold
             if (Math.abs(delta) > maxDelta) {


### PR DESCRIPTION
Proposed addition of two parameters to popular `pixelmatch` library:
- horizontalShiftPixels
- verticalShiftPixels

Setting these parameters > 0 makes `pixelmatch` do additional checking for neighboring pixels within plus-or-minus horizontal/vertical "shift pixels" to avoid false-positives when the browser misaligns text by a few pixes.
- Only execute this more expensive operation if the original pixel position mis-matches

Useful for `jest-puppeteer` testing screenshot matching where Chrome/Firefox text rendering is slightly shifted even on the same machine like this difference with original `pixelmatch`:
<img width="126" alt="image" src="https://user-images.githubusercontent.com/25495544/156268537-ffbc1156-2a66-4370-a005-66b21b7e7556.png">
