### PR TITLE
Fix line-endings on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout, so that it matches the configured eslint rules.
+*.js text eol=lf
+bin/pixelmatch text eol=lf


### PR DESCRIPTION
`yarn run test` doesn't work on Windows, because the line-endings are checked out differently than the configured ESLint rules.

This .gitattributes file makes sure that `*.js` files and `bin/pixelmatch` are checked out with Linux line-endings on Windows. This way, `yarn run test` can be executed successfully on my machine.