### PR TITLE
Add TypeScript types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .nyc_output
 coverage
 tmp
+index.d.ts

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 ISC License
 
-Copyright (c) 2024, Mapbox
+Copyright (c) 2025, Mapbox
 
 Permission to use, copy, modify, and/or distribute this software for any purpose
 with or without fee is hereby granted, provided that the above copyright notice

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
       },
       "devDependencies": {
         "eslint": "^9.20.1",
-        "eslint-config-mourner": "^4.0.2"
+        "eslint-config-mourner": "^4.0.2",
+        "typescript": "^5.7.3"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -1089,6 +1090,20 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.3.tgz",
+      "integrity": "sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -4,22 +4,25 @@
   "type": "module",
   "description": "The smallest and fastest pixel-level image comparison library.",
   "main": "index.js",
+  "types": "index.d.ts",
   "bin": {
     "pixelmatch": "bin/pixelmatch"
   },
   "files": [
-    "bin/pixelmatch"
+    "bin/pixelmatch",
+    "index.d.ts"
   ],
   "dependencies": {
     "pngjs": "^7.0.0"
   },
   "devDependencies": {
     "eslint": "^9.20.1",
-    "eslint-config-mourner": "^4.0.2"
+    "eslint-config-mourner": "^4.0.2",
+    "typescript": "^5.7.3"
   },
   "scripts": {
     "pretest": "eslint",
-    "test": "node --test"
+    "test": "tsc && node --test"
   },
   "repository": {
     "type": "git",
@@ -30,7 +33,7 @@
     "comparison",
     "diff"
   ],
-  "author": "Vladimir Agafonkin",
+  "author": "Volodymyr Agafonkin",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/mapbox/pixelmatch/issues"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+    "compilerOptions": {
+        "allowJs": true,
+        "checkJs": true,
+        "strict": true,
+        "emitDeclarationOnly": true,
+        "declaration": true,
+        "target": "es2017",
+        "module": "nodenext",
+        "moduleResolution": "nodenext"
+    },
+    "files": [
+        "index.js"
+    ]
+}


### PR DESCRIPTION
Add first-class TypeScript types via JSDoc comments. Close #139.